### PR TITLE
Run conversion programs under cgroup limitation of 80% available memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-alpine
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG USER_ID=1000
 
 WORKDIR /app
@@ -13,22 +13,24 @@ ENV UV_LINK_MODE=copy
 RUN adduser -S -u $USER_ID appuser
 
 # Add poppler utils for pdftotext
-RUN apk add --no-cache poppler-utils
+RUN apt-get update && apt install -y sudo cgroup-tools poppler-utils && rm -rf /var/lib/apt/lists/*
 
 # Copy the script and uv config
 COPY webserver.py /app/webserver.py
 COPY uv.lock /app/uv.lock
 COPY pyproject.toml /app/pyproject.toml
+COPY run-me.sh /app/run-me.sh
 
 # Install the project's dependencies using the lockfile and settings
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev
 
 # Switch to non-root user
-USER appuser
+# this is done in run-me.sh
+# USER appuser
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Run this when a container is started
-CMD ["hypercorn", "--bind", "0.0.0.0:8888", "webserver:app"]
+CMD ["/app/run-me.sh"]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,61 @@
+arxiv-pdftotext
+===============
 
-arxiv-pdftotext. As a webservice, containerized! The image is based on Alpine.
+Convert PDFs to text as webservice.
 
 Forked and extended from https://github.com/sdenel/pdftotext-docker-rest
+with the following changes:
+
+- provide multiple modes to convert
+- allow reading PDF from GCS bucket
+- run conversion under cgroup with memory limit
+
 
 ## Usage
 
-Run the service:
+This repository uses [`uv`](https://docs.astral.sh/uv/). In the following
+we assume that `uv` is installed.
 
-```bash
-docker run -d -p8888:8888 arxiv-pdftotext:latest
+### Setup the Python environment
+
+Run
 ```
+uv sync
+```
+to install dependencies (including development dependencies) into a new
+virtualenv in `.venv`.
+
+### Start service locally
+
+Run
+```
+uv run hypercorn --bind 0.0.0.0:8888 webserver:app
+```
+
+### Docker
+
+#### Build docker image
+
+Run
+```
+docker build -t arxiv-pdftotext:latest .
+```
+
+#### Run docker service:
+
+Start the docker service with
+```bash
+docker run --privileged --cgroupns=host -d -p8888:8888 arxiv-pdftotext:latest
+```
+
+### Sending files for conversion
 
 Two modes are supported:
 - pdftotext: uses the poppler utilities tool `pdftotext`
 - pdf2txt: uses the pdfminer.six tool `pdf2txt.py`
 
-Example of usage:
-
 Default mode is `pdftotext`
+
 ```bash
 wget http://www.xmlpdf.com/manualfiles/hello-world.pdf
 curl -F "file=@hello-world.pdf;" http://localhost:8888/
@@ -26,5 +64,21 @@ curl -F "file=@hello-world.pdf;" http://localhost:8888/
 Passing a different mode:
 ```bash
 curl -F "file=@hello-world.pdf;" -F "mode=pdf2txt;" http://localhost:8888/
+```
+
+
+## Todo
+
+- auto-fallback: if mode=auto, first try pdftotext, if that fails/runs out of
+  memory, try pdfminer/pdf2text.py
+
+
+## Development
+
+We provide a pre-commit configuration file. We strongly recommend activating
+the pre-commit hook by e.g. running
+```
+uv tool install pre-commit --with pre-commit-uv --force-reinstall
+pre-commit install --install-hooks
 ```
 

--- a/run-me.sh
+++ b/run-me.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Set Bash "strict" mode
+# see: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+# these need to be in sync with:
+# - webserver.py: variable CGROUPNAME
+# - Dockerfile: adduser call
+APPUSER=appuser
+CGROUPNAME=pdftotext
+
+total_mem_in_kb=$(cat /proc/meminfo | grep MemFree | awk '{ print $2 }')
+total_mem=$(( total_mem_in_kb * 1024 ))
+avail_mem=$(( total_mem * 8 / 10))
+
+# create cgroup that $APPUSER can use
+cgcreate -t $APPUSER:nogroup -a $APPUSER:nogroup -g memory:$CGROUPNAME
+
+# "/sys/fs/cgroup/memory/memory.limit_in_bytes",  # cgroups v1 hard limit
+# "/sys/fs/cgroup/memory/memory.soft_limit_in_bytes",  # cgroups v1 soft limit
+# "/sys/fs/cgroup/memory.max",  # cgroups v2 hard limit
+# "/sys/fs/cgroup/memory.high",  # cgroups v2 soft limit
+if [ -r /sys/fs/cgroup/cgroup.controllers ] ; then
+  # cgroups v2
+  # we cannot simply create a group since in v2 access control is more strict
+  # and we need access to cgroup.procs
+  # One might be able to work around this according to the following document,
+  # but that complicates a lot of things:
+  # - https://unix.stackexchange.com/questions/725112/using-cgroups-v2-without-root
+  echo "Detected cgroups v2" >&2
+  chmod go+w /sys/fs/cgroup/cgroup.procs
+  echo $avail_mem > /sys/fs/cgroup/${CGROUPNAME}/memory.max
+else
+  # cgroups v1
+  echo "Detected cgroups v1" >&2
+  echo $avail_mem > /sys/fs/cgroup/memory/${CGROUPNAME}/memory.limit_in_bytes
+fi
+
+sudo -u $APPUSER /app/.venv/bin/hypercorn --bind 0.0.0.0:8888 webserver:app
+

--- a/webserver.py
+++ b/webserver.py
@@ -16,6 +16,8 @@ from google.cloud import storage
 from google.cloud.storage.blob import Blob
 from starlette.background import BackgroundTask
 
+CGROUPNAME = "pdftotext"
+
 PARAM2PROGRAM_DEFAULTS = {
     "pdftotext": "pdftotext",
     "pdf2txt": "pdf2txt.py",
@@ -59,7 +61,7 @@ def convert_file(temp_dir: str, file_path_in: str, mode: str, params: str):
     file_path_out = file_path_in + ".txt"
     if mode not in PARAM2PROGRAM_FOUND.keys():
         raise HTTPException(status_code=400, detail=f"Invalid mode: {mode}")
-    cmd = [PARAM2PROGRAM_FOUND[mode]]
+    cmd = ["cgexec", "-g", f"memory:{CGROUPNAME}", PARAM2PROGRAM_FOUND[mode]]
 
     logging.debug("mode=%s file_path_in=%s file_path_out=%s params=%s", mode, file_path_in, file_path_out, params)
     if params:


### PR DESCRIPTION
Changes made:
- switch to Debian/bookworm as base image
- add a docker entrypoint script that:
  . creates a new cgroup for the process with access rights for the app user
  . sets the memory limit
  . start hypercorn as app user
